### PR TITLE
Localising text, option to show master price.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ These configuration options can be set in a config/initializers/spree_variant_op
 ```ruby
 SpreeVariantOptions::VariantConfig.allow_select_outofstock = true
 SpreeVariantOptions::VariantConfig.default_instock = true
+
+# When false, the master price is shown before any variants are selected
+# When true, 'Select Variant' text is show in the price display and then the price
+# is shown after the user selects their variants.
+SpreeVariantOptions::VariantConfig.hide_master_price = false
 ```
 
 ### Storage options

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -11,7 +11,6 @@ SpreeVariantOption.OptionValuesHandler = function(options) {
   this.quantityField = options.quantityField;
   this.variantField = options.variantField;
   this.thumbImages = options.thumbImages;
-  this.locale = options.locale;
   this.variantId = 0;
   this.variantPrice = 0;
 };
@@ -175,7 +174,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.showVariantImages = function(va
 };
 
 SpreeVariantOption.OptionValuesHandler.prototype.label = function(name, locale) {
-  if (!locale) { locale = this.locale; }
+  if (!locale) { locale = variant_options_config.locale; }
   var locales = {
     en: {
       select_variant: 'Select variant'
@@ -195,7 +194,6 @@ $(function () {
     quantityField: $('#quantity'),
     variantField: $('#variant_id'),
     thumbImages: $('li.vtmb'),
-    clearButtons: $('.clear-button'),
-    locale: Spree.url_params.locale || 'en'
+    clearButtons: $('.clear-button')
   })).init();
 });

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -40,7 +40,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.optionsButtonClickHandler = fun
       _this.resetAllNextLevel($this);
       _this.unlockNextLevel($this);
 
-      if($this.data('level') == options["option_type_count"]) {
+      if($this.data('level') == options.option_type_count) {
         _this.setVariantWithSelecetedValues();
       }
     }
@@ -128,7 +128,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.unlockNextLevel = function(opti
     if(details) {
       availableOptionValueCount += 1;
       availableOptionValue = $this;
-      if(($this.data('level') == options["option_type_count"]) && !details["inStock"] && !options["allow_select_outofstock"]) {
+      if(($this.data('level') == options.option_type_count) && !details.inStock && !options.allow_select_outofstock) {
         $this.addClass('out-of-stock');
       } else {
         $this.removeClass('out-of-stock locked');

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -62,7 +62,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.disableCartInputFields = functi
   this.addToCartButton.prop('disabled', value);
   this.quantityField.prop('disabled', value);
 
-  if(value) { this.priceHeading.html(this.label('select_variant')); }
+  if(value) { this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown'); }
 };
 
 SpreeVariantOption.OptionValuesHandler.prototype.updateSiblings = function(optionValue) {
@@ -104,10 +104,10 @@ SpreeVariantOption.OptionValuesHandler.prototype.anyVariantExists = function(con
 SpreeVariantOption.OptionValuesHandler.prototype.setVariantId = function(is_exist) {
   if(is_exist) {
     this.variantField.val(this.variantId);
-    this.priceHeading.html(this.variantPrice);
+    this.priceHeading.html(this.variantPrice).removeClass('price-not-shown');
   } else {
     this.variantField.val('');
-    this.priceHeading.html(this.label('select_variant'));
+    this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown');
   }
 };
 

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -24,7 +24,6 @@ SpreeVariantOption.OptionValuesHandler.prototype.init = function() {
 SpreeVariantOption.OptionValuesHandler.prototype.bindEvents = function() {
   this.optionsButtonClickHandler();
   this.clearButtonClickHandler();
-
 };
 
 SpreeVariantOption.OptionValuesHandler.prototype.optionsButtonClickHandler = function() {
@@ -191,6 +190,9 @@ SpreeVariantOption.OptionValuesHandler.prototype.label = function(name, locale) 
 };
 
 $(function () {
+  if (typeof(variant_options_config) == 'undefined') {
+    return;
+  }
   (new SpreeVariantOption.OptionValuesHandler({
     optionsButton: $('.option-value'),
     addToCartButton: $('#add-to-cart-button'),

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -40,7 +40,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.optionsButtonClickHandler = fun
       _this.resetAllNextLevel($this);
       _this.unlockNextLevel($this);
 
-      if($this.data('level') == options.option_type_count) {
+      if($this.data('level') == variant_options_config.option_type_count) {
         _this.setVariantWithSelecetedValues();
       }
     }
@@ -128,7 +128,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.unlockNextLevel = function(opti
     if(details) {
       availableOptionValueCount += 1;
       availableOptionValue = $this;
-      if(($this.data('level') == options.option_type_count) && !details.inStock && !options.allow_select_outofstock) {
+      if(($this.data('level') == variant_options_config.option_type_count) && !details.inStock && !variant_options_config.allow_select_outofstock) {
         $this.addClass('out-of-stock');
       } else {
         $this.removeClass('out-of-stock locked');

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -61,7 +61,9 @@ SpreeVariantOption.OptionValuesHandler.prototype.disableCartInputFields = functi
   this.addToCartButton.prop('disabled', value);
   this.quantityField.prop('disabled', value);
 
-  if(value) { this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown'); }
+  if(value && variant_options_config.hide_master_price) {
+    this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown');
+  }
 };
 
 SpreeVariantOption.OptionValuesHandler.prototype.updateSiblings = function(optionValue) {
@@ -106,7 +108,9 @@ SpreeVariantOption.OptionValuesHandler.prototype.setVariantId = function(is_exis
     this.priceHeading.html(this.variantPrice).removeClass('price-not-shown');
   } else {
     this.variantField.val('');
-    this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown');
+    if (variant_options_config.hide_master_price) {
+      this.priceHeading.html(this.label('select_variant')).addClass('price-not-shown');
+    }
   }
 };
 

--- a/app/assets/javascripts/spree/frontend/spree_variant_options.js
+++ b/app/assets/javascripts/spree/frontend/spree_variant_options.js
@@ -2,15 +2,16 @@
 //= require extentions/array
 //= require extentions/global_methods
 
-var SpreeVariantOption = {}
-SpreeVariantOption.OptionValuesHandler = function(selectors) {
-  this.optionsButton = selectors.optionsButton;
-  this.addToCartButton = selectors.addToCartButton;
-  this.clearButtons = selectors.clearButtons;
-  this.priceHeading = selectors.priceHeading;
-  this.quantityField = selectors.quantityField;
-  this.variantField = selectors.variantField;
-  this.thumbImages = selectors.thumbImages;
+var SpreeVariantOption = {};
+SpreeVariantOption.OptionValuesHandler = function(options) {
+  this.optionsButton = options.optionsButton;
+  this.addToCartButton = options.addToCartButton;
+  this.clearButtons = options.clearButtons;
+  this.priceHeading = options.priceHeading;
+  this.quantityField = options.quantityField;
+  this.variantField = options.variantField;
+  this.thumbImages = options.thumbImages;
+  this.locale = options.locale;
   this.variantId = 0;
   this.variantPrice = 0;
 };
@@ -61,7 +62,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.disableCartInputFields = functi
   this.addToCartButton.prop('disabled', value);
   this.quantityField.prop('disabled', value);
 
-  if(value) { this.priceHeading.html('Select Variant'); }
+  if(value) { this.priceHeading.html(this.label('select_variant')); }
 };
 
 SpreeVariantOption.OptionValuesHandler.prototype.updateSiblings = function(optionValue) {
@@ -106,7 +107,7 @@ SpreeVariantOption.OptionValuesHandler.prototype.setVariantId = function(is_exis
     this.priceHeading.html(this.variantPrice);
   } else {
     this.variantField.val('');
-    this.priceHeading.html('Select Variant');
+    this.priceHeading.html(this.label('select_variant'));
   }
 };
 
@@ -173,6 +174,19 @@ SpreeVariantOption.OptionValuesHandler.prototype.showVariantImages = function(va
   imagesToShow.first().trigger('mouseenter');
 };
 
+SpreeVariantOption.OptionValuesHandler.prototype.label = function(name, locale) {
+  if (!locale) { locale = this.locale; }
+  var locales = {
+    en: {
+      select_variant: 'Select variant'
+    },
+    da: {
+      select_variant: 'Vælg variant'
+    }
+  };
+  return locales[locale][name];
+};
+
 $(function () {
   (new SpreeVariantOption.OptionValuesHandler({
     optionsButton: $('.option-value'),
@@ -181,6 +195,7 @@ $(function () {
     quantityField: $('#quantity'),
     variantField: $('#variant_id'),
     thumbImages: $('li.vtmb'),
-    clearButtons: $('.clear-button')
+    clearButtons: $('.clear-button'),
+    locale: Spree.url_params.locale || 'en'
   })).init();
 });

--- a/app/models/spree/app_configuration/variant_configuration.rb
+++ b/app/models/spree/app_configuration/variant_configuration.rb
@@ -2,5 +2,6 @@ module SpreeVariantOptions
   class VariantConfiguration < Spree::Preferences::Configuration
     preference :allow_select_outofstock, :boolean, default: false
     preference :default_instock, :boolean, default: false
+    preference :hide_master_price, :boolean, default: true
   end
 end

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -29,6 +29,7 @@
         option_type_count: <%== ordered_option_types.length %>,
         allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] %>,
         default_instock: <%== !!SpreeVariantOptions::VariantConfig[:default_instock] %>,
+        hide_master_price: <%== !!SpreeVariantOptions::VariantConfig[:hide_master_price] %>,
         locale: "<%= Spree::Frontend::Config[:locale] %>"
       }
     //]]>

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -28,7 +28,8 @@
       var variant_options_config = {
         option_type_count: <%== ordered_option_types.length %>,
         allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] %>,
-        default_instock: <%== !!SpreeVariantOptions::VariantConfig[:default_instock] %>
+        default_instock: <%== !!SpreeVariantOptions::VariantConfig[:default_instock] %>,
+        locale: "<%= Spree::Frontend::Config[:locale] %>"
       }
     //]]>
     </script>

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -25,12 +25,11 @@
     <script type="text/javascript">
     //<![CDATA[
       var variant_option_details = <%== @product.variants_option_value_details.to_json %>
-      var options = {
+      var variant_options_config = {
         option_type_count: <%== ordered_option_types.length %>,
         allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] %>,
         default_instock: <%== !!SpreeVariantOptions::VariantConfig[:default_instock] %>
       }
-
     //]]>
     </script>
   </ul>


### PR DESCRIPTION
1. The 'Select Variant' text can now be localised. I've only added Danish so far
2. New `hide_master_price` (default `true` to maintain original functionality) option. When set to false,  the master price is shown instead of 'Select Variant' text.